### PR TITLE
Fix issues in fib.ts

### DIFF
--- a/src/fib.ts
+++ b/src/fib.ts
@@ -1,5 +1,5 @@
 // util function that computes the fibonacci numbers
-export default function fibonacci(n) {
+export default function fibonacci(n: number): number {
   if (n < 0) {
     return -1;
   } else if (n == 0) {


### PR DESCRIPTION
Explicitly typed the input `n` and the return type of the method `fibonacci`.

All lint errors for `fib.ts` no longer appear when eslint is run.